### PR TITLE
Modified desired table logic

### DIFF
--- a/src/main/java/model/Timetable.java
+++ b/src/main/java/model/Timetable.java
@@ -41,7 +41,7 @@ public class Timetable {
             throw new InvalidParameterException("The given URL does not contain the timetable for group " + group);
         }
 
-        List<String> tableOfGroup = getTableOfGroup(htmlCode, group);
+        List<String> tableOfGroup = getTableOfGroup(htmlCode);
         List<List<String>> rows = divideIntoRows(tableOfGroup);
         rows.forEach(row -> allActivities.add(processRow(row)));
         filterActivities();
@@ -56,30 +56,25 @@ public class Timetable {
                .collect(Collectors.toList());
     }
 
-    private List<String> getTableOfGroup(List<String> htmlCode, final String group) {
-        Pattern beginningOfTable = Pattern.compile("<table .*>");
+    private List<String> getTableOfGroup(List<String> htmlCode) {
         Pattern endOfTable = Pattern.compile("</table>");
+        Pattern groupPattern = Pattern.compile(".*Grupa " + group + ".*" + semiGroup + ".*");
 
-        int wantedTable = group.charAt(group.length() - 1) - '0';
         int indexOfBeginning = -1, indexOfEnd = -1;
 
-        for (int i = 0, foundTable = 0; i < htmlCode.size(); i++) {
-            if (foundTable < wantedTable) {
-                Matcher matcherTable = beginningOfTable.matcher(htmlCode.get(i));
-                if (matcherTable.matches()) {
-                    foundTable++;
-                    if (wantedTable == foundTable) {
-                        indexOfBeginning = i + 1;
-                    }
-                }
+        for (int i = 0; i < htmlCode.size(); i++) {
+            Matcher groupMatcher = groupPattern.matcher(htmlCode.get(i));
+            if (groupMatcher.matches()) {
+                indexOfBeginning = i + 2;
+                break;
             }
+        }
 
-            if (foundTable == wantedTable) {
-                Matcher matcherEndTable = endOfTable.matcher(htmlCode.get(i));
-                if (matcherEndTable.matches()) {
-                    indexOfEnd = i;
-                    break;
-                }
+        for (int i = indexOfBeginning; i < htmlCode.size(); i++) {
+            Matcher matcherEndTable = endOfTable.matcher(htmlCode.get(i));
+            if (matcherEndTable.matches()) {
+                indexOfEnd = i;
+                break;
             }
         }
 

--- a/src/main/java/utils/SemesterInfo.java
+++ b/src/main/java/utils/SemesterInfo.java
@@ -6,11 +6,11 @@ public class SemesterInfo {
     public static final int CHRISTMAS_HOLIDAY_LENGTH = 2;
 
     public static final int NO_OF_WEEKS_SECOND_SEMESTER = 13;
-    public static final int EASTER_HOLIDAY = 6;
+    public static final int EASTER_HOLIDAY = 10;
     public static final int EASTER_HOLIDAY_LENGTH = 1;
 
-    public static final String STARTING_DATE_FIRST_SEMESTER = "2018-10-01";
-    public static final String STARTING_DATE_SECOND_SEMESTER = "2019-02-25";
+    public static final String STARTING_DATE_FIRST_SEMESTER = "2020-09-28";
+    public static final String STARTING_DATE_SECOND_SEMESTER = "2021-02-22";
 
     public static int getNoOfWeeks(int semester) {
         return (semester == 1 ? NO_OF_WEEKS_FIRST_SEMESTER : NO_OF_WEEKS_SECOND_SEMESTER);


### PR DESCRIPTION
* It was the case the the desired table was computed by
taking the last digit of the group, and saying that the
table on that position in the HTML was desired. This
does not work for cases where the last digit does
not represent the actual index of the desired table.

* The current implementation takes advantage of the
label that always precedes the tables. If you want table
248/2, then it will look for that label, and take the next
table it finds from there.